### PR TITLE
Don't use alpine images

### DIFF
--- a/TRENZ.Docs.API/Dockerfile
+++ b/TRENZ.Docs.API/Dockerfile
@@ -1,11 +1,11 @@
 ﻿#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 COPY ["TRENZ.Docs.API.csproj", "."]
 RUN dotnet restore "TRENZ.Docs.API.csproj"


### PR DESCRIPTION
_Something_ has changed and is causing libgit2sharp to fail at run time (see https://github.com/trenz-gmbh/trenz-docs-api/actions/runs/5430785723/jobs/9876734185).

The easiest fix seems to be to not use alpine base images for aspnet.